### PR TITLE
Added support for overriding arbitrary packaging props

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -4,9 +4,11 @@
   <ItemGroup>
     <NuGetize Include="Mono.Posix">
       <Description>POSIX interface for Mono and .NET.</Description>
+      <Versioning>Mono</Versioning>
     </NuGetize>
     <NuGetize Include="Mono.Security">
       <Description>Mono.Security containing utilities like Authenticode.</Description>
+      <Versioning>Mono</Versioning>
     </NuGetize>
   </ItemGroup>
 

--- a/build.targets
+++ b/build.targets
@@ -22,11 +22,21 @@
     <Package Include="$(BinDir)*.nupkg" />
   </ItemGroup>
 
+  <Target Name="Echo" Returns="@(_NuGetize)">
+    <SetAdditionalProperties Items="@(NuGetize)">
+      <Output TaskParameter="Result" ItemName="_NuGetize" />
+    </SetAdditionalProperties>
+  </Target>
+
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)">
-    <Message Text="Building packages for version v$(Version)" Importance="high" />
+    <Message Text="Building packages from Mono version v$(MonoVersion)" Importance="high" />
+
+    <SetAdditionalProperties Items="@(NuGetize)">
+      <Output TaskParameter="Result" ItemName="_NuGetize" />
+    </SetAdditionalProperties>
 
     <MSBuild Projects="package\Mono.proj"
-             Properties="AssemblyName=%(NuGetize.Identity);Version=$(Version);Description=%(NuGetize.Description)" />
+             Properties="AssemblyName=%(_NuGetize.Identity);MonoVersion=$(MonoVersion);%(_NuGetize.AdditionalProperties)" />
   </Target>
 
   <Target Name="_AfterRestore" AfterTargets="Restore">
@@ -40,12 +50,12 @@
     </HttpClient>
 
     <PropertyGroup>
-      <Version>$([System.Text.RegularExpressions.Regex]::Match("$(Manifest)", "(?&lt;=\().*(?=\))").Value)</Version>
+      <MonoVersion>$([System.Text.RegularExpressions.Regex]::Match("$(Manifest)", "(?&lt;=\().*(?=\))").Value)</MonoVersion>
       <MsiInstaller>$([System.Text.RegularExpressions.Regex]::Match("$(Manifest)", "(?&lt;=:\s).*-x64-\d\.msi").Value)</MsiInstaller>
       <PkgInstaller>$([System.Text.RegularExpressions.Regex]::Match("$(Manifest)", "(?&lt;=:\s).*\.pkg").Value)</PkgInstaller>
     </PropertyGroup>
 
-    <Message Importance="high" Text="##vso[build.updatebuildnumber]$(Version)-$(BUILD_BUILDID)" />
+    <Message Importance="high" Text="##vso[build.updatebuildnumber]$(MonoVersion)-$(BUILD_BUILDID)" />
 
     <ItemGroup>
       <MsiInstaller Include="$(MsiInstaller)">

--- a/build.tasks
+++ b/build.tasks
@@ -115,4 +115,27 @@
     </Task>
   </UsingTask>
 
+  <UsingTask TaskName="SetAdditionalProperties" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <Items ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <Result ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.Reflection" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+          foreach (var item in Items)
+          {
+	          item.SetMetadata("AdditionalProperties", string.Join(";", 
+		          item.CloneCustomMetadata()
+			          .OfType<KeyValuePair<string, string>>()
+			          .Select(x => x.Key + "=" + x.Value)));
+          }
+
+          Result = Items;
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
 </Project>

--- a/package/Mono.proj
+++ b/package/Mono.proj
@@ -1,13 +1,23 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" TreatAsLocalProperty="Description;PackageReleaseNotes" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\build.props" />
 
   <!-- Package metadata -->
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <PackageVersion>$(Version)</PackageVersion>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">0.1.0</PackageVersion>
+    <PackageVersion Condition="'$(Versioning)' == 'Mono'">$(MonoVersion)</PackageVersion>
+
     <Authors>Mono</Authors>
     <Description Condition="'$(Description)' == ''">$(PackageId)</Description>
+    <PackageProjectUrl>https://github.com/mono/mono</PackageProjectUrl>
+
+    <Description>$(Description.Replace('$MonoVersion$', '$(MonoVersion)'))</Description>
+    <PackageReleaseNotes>$(PackageReleaseNotes.Replace('$MonoVersion$', '$(MonoVersion)'))</PackageReleaseNotes>
+
+    <!-- Wheter the assembly is pure MSIL with no platform specific flags/implementations
+         We default to consider everything platform-specific, requiring per-platform 
+         assemblies and targets that reference them.
+    -->
+    <XPlat Condition="'$(XPlat)' == ''">false</XPlat> 
   </PropertyGroup>
 
   <!-- Package build props -->
@@ -20,19 +30,45 @@
 
   <PropertyGroup>
     <WinPath>$(ObjDir)Win\msi\Mono\lib\mono\4.5</WinPath>
-    <MacPath>$(ObjDir)Mac\Library\Frameworks\Mono.framework\Versions\$([System.Text.RegularExpressions.Regex]::Match("$(PackageVersion)", "\d+\.\d+\.\d+").Value)\lib\mono\4.5</MacPath>
+    <MacPath>$(ObjDir)Mac\Library\Frameworks\Mono.framework\Versions\*\lib\mono\4.5</MacPath>
   </PropertyGroup>
 
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
+  <Target Name="Build" DependsOnTargets="_SetPackageVersion;$(BuildDependsOn)" />
+
+  <Target Name="_SetPackageVersion" Condition="'$(PackageVersion)' == ''">
+    <GetAssemblyVersion AssemblyFile="$(WinPath)\$(AssemblyName).dll">
+      <Output TaskParameter="AssemblyVersion" PropertyName="PackageVersion" />
+    </GetAssemblyVersion>
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Packaging" Version="*" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(XPlat)' == 'false'">
     <PackageFile Include="$(AssemblyName).targets" PackagePath="build\net45\$(AssemblyName).targets" />
-
     <PackageFile Include="$(WinPath)\$(AssemblyName).dll" PackagePath="build\net45\win\$(AssemblyName).dll" />
     <PackageFile Include="$(MacPath)\$(AssemblyName).dll" PackagePath="build\net45\mac\$(AssemblyName).dll" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(XPlat)' == 'true'">
+    <PackageFile Include="$(WinPath)\$(AssemblyName).dll" PackagePath="lib\net45\$(AssemblyName).dll" />
+  </ItemGroup>
+
   <Import Project="..\build\corebuild.targets" />
+
+  <UsingTask TaskName="GetAssemblyVersion" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <AssemblyFile Required="true" />
+      <AssemblyVersion Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.Reflection" />
+      <Code Type="Fragment" Language="cs">
+        var name = AssemblyName.GetAssemblyName(AssemblyFile);
+        AssemblyVersion = name.Version.Major + "." + name.Version.Minor + "." + name.Version.Build;
+      </Code>
+    </Task>
+  </UsingTask>
+
 </Project>


### PR DESCRIPTION
By turning the @(NuGetize) custom metadata into AdditionalProperties we can
pass them when building the package and allow the item definition to control
all properties of a package, including the target package id, project URL and
so on.

Added support for selecting either Mono versioning or Assembly versioning for
the package. For the later case, we also add token replacement of $MonoVersion$
in the Description and PackageReleaseNotes so that you can provide a friendly
description that mentions what Mono the given assembly first shipped with.